### PR TITLE
Change update URL to upstream

### DIFF
--- a/signal.py
+++ b/signal.py
@@ -44,7 +44,7 @@ default_options = {
     'debug': '',
     'sentry_dsn': '',
     'number': '',
-    'signal_cli_update_url': 'https://api.github.com/repos/thefinn93/signal-cli/releases/latest',
+    'signal_cli_update_url': 'https://api.github.com/repos/AsamK/signal-cli/releases/latest',
     'signal_cli_command': 'signal-cli',
     'autoupgrade': 'off'
 }


### PR DESCRIPTION
This PR changes the update URL for `signal-cli` to upstream instead of the fork maintained by @thefinn93.

I understand the rationale behind why we'd want to branch off of a stable fork, but seeing as how neither this project nor the `signal-cli` fork have been updated in a long while, it makes sense to me to base the update URL off of upstream.