### PR TITLE
Respect bus option

### DIFF
--- a/signal.py
+++ b/signal.py
@@ -101,7 +101,14 @@ def config_changed(data, option, value):
 
 
 def getSignal():
-    bus = dbus.SessionBus()
+    try:
+        if options['bus'] == 'session':
+            bus = dbus.SessionBus()
+        else:
+            bus = dbus.SystemBus()
+    except dbus.exceptions.DBusException as err:
+        if err.get_dbus_message() == "org.freedesktop.DBus.Error.NotSupported: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11":
+            raise "Unable to find a DBus daemon to connect to. Try connecting to a system DBus daemon running '/set plugins.var.python.signal.bus system' in WeeChat; confirming that a DBus session daemon is running and setting the DBUS_SESSION_BUS_ADDRESS environment variable; or making sure that X11 is running and that the DISPLAY environment variable is set. Also confirm that signal-cli is running and connected to whichever bus you connect to (system or session)."
     return bus.get_object('org.asamk.Signal', '/org/asamk/Signal')
 
 


### PR DESCRIPTION
This PR causes `signal-weechat` to respect the `plugins.var.python.signal.bus` option, which can either be set to `session` or `system`, depending on whether you want to connect to a session or system DBus daemon.

Addresses (and arguably fixes) https://github.com/thefinn93/signal-weechat/issues/13.